### PR TITLE
Fix: Show recent GIFs and categories and subcategories when search input is empty

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="tabSettings">
+      <map>
+        <entry key="Firebase Crashlytics">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="com.optimum.coolkeybord" />
+                  <option name="mobileSdkAppId" value="1:252887680410:android:a32ccf966f6f733e74a623" />
+                  <option name="projectId" value="coolkeybord" />
+                  <option name="projectNumber" value="252887680410" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="THIRTY_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/app/src/main/java/com/optimum/coolkeybord/gifview/Gifgridviewpopup.java
+++ b/app/src/main/java/com/optimum/coolkeybord/gifview/Gifgridviewpopup.java
@@ -107,7 +107,7 @@ public class Gifgridviewpopup extends PopupWindow {
         LayoutInflater inflater = (LayoutInflater) mContext.getSystemService(Activity.LAYOUT_INFLATER_SERVICE);
         //++++++++++++++it will be null as it is independent view++++++++++++++++
         @SuppressLint("InflateParams") View view = inflater.inflate(R.layout.gifgridviewlayout, null, false);
-         recent_gfs = (LinearLayout) view.findViewById(R.id.recent_gfs);
+        recent_gfs = (LinearLayout) view.findViewById(R.id.recent_gfs);
         gifgridlay = (RecyclerView) view.findViewById(R.id.gridlay);
         recentgifrec = (RecyclerView) view.findViewById(R.id.recentgif);
         ///+++++++++++++++++++++++++++++++++++++++++++Gif made++++++++++++++++++++++++++++++++++++++++++++++
@@ -182,29 +182,29 @@ public class Gifgridviewpopup extends PopupWindow {
                 try {
                     JSONObject obejct   = new JSONObject(gifEntities.get(i).gifjson);
                     Log.w("gifs" , "saved"+obejct.getString("gif"));
-                if( i==0){
+                    if( i==0){
 //                        Log.e("gifs" , "saved"+obejct.toString());
                         recentsubgifdataArrayList.add(new Gifdata(obejct.getString("multiline_text") ,obejct.getString("gif")
                                 ,obejct.getString("thumbnail_gif") ,obejct.getString("youtube_url") , false));
-                         firstgif = obejct;
+                        firstgif = obejct;
 
 
-                }
-                else {
-                    try {
-                        assert firstgif != null;
-                        if(!(firstgif.getString("gif").equals(obejct.getString("gif"))))
-
-                        {
-                            recentsubgifdataArrayList.add(new Gifdata(obejct.getString("multiline_text") ,obejct.getString("gif")
-                                    ,obejct.getString("thumbnail_gif") ,obejct.getString("youtube_url") , false));
-                        }else {
-                            firstgif = obejct;
-                        }
-                    } catch (JSONException e) {
-                        e.printStackTrace();
                     }
-                }
+                    else {
+                        try {
+                            assert firstgif != null;
+                            if(!(firstgif.getString("gif").equals(obejct.getString("gif"))))
+
+                            {
+                                recentsubgifdataArrayList.add(new Gifdata(obejct.getString("multiline_text") ,obejct.getString("gif")
+                                        ,obejct.getString("thumbnail_gif") ,obejct.getString("youtube_url") , false));
+                            }else {
+                                firstgif = obejct;
+                            }
+                        } catch (JSONException e) {
+                            e.printStackTrace();
+                        }
+                    }
                 } catch (JSONException e) {
                     e.printStackTrace();
                 }
@@ -250,14 +250,21 @@ public class Gifgridviewpopup extends PopupWindow {
             setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
             Intent intent = new Intent(view12.getContext() ,DictionaryActivity.class);
             intent.setFlags(FLAG_ACTIVITY_NEW_TASK);
-          view12.getContext().startActivity(intent);
+            view12.getContext().startActivity(intent);
         });
 
+        // Normalize empty search input to trigger recent + categories
         Log.e("searchtext" ,""+searchtext);
-        if(searchtext.equals(""))
+        if(searchtext == null || searchtext.trim().isEmpty() || searchtext.equalsIgnoreCase("null"))     // Fix: Show recent GIFs and categories when no search input is entered
         {
+            Log.d("Gifgridviewpopup","Search text is empty showing recent + categories.");
+            recentgifrec.setVisibility(View.VISIBLE);
+            gifgridlay.setVisibility(View.GONE);
             makeCategories(view);
         }else {
+            Log.d("Gifridviewpopup","Search text: " + searchtext);  // If input is present, load matched gifs from API
+            recentgifrec.setVisibility(View.GONE);
+            gifgridlay.setVisibility(View.VISIBLE);
             getSubcategorieswithString(searchtext , mContext ,view);
         }
         emojis_keyboard_image =  view.findViewById(R.id.emojis_keyboard_image);
@@ -479,9 +486,14 @@ public class Gifgridviewpopup extends PopupWindow {
                     }
                 }
             });
+            //Auto-select first category and its subcategories if search is empty
             if(searchtext.isEmpty())
             {
                 categoriesmodelArrayList.get(0).setSelectedornot(true);
+                subcatadapter.notifyItemChanged(0);
+
+                // Load gifs for first subcategory
+                getSubcategories(subcategoriesmodelArrayList.get(0).getSubcategoryid(), mContext, 1);
             }else {
                 context.findViewById(R.id.emojis_keyboard_image).setBackground(context.getContext().getDrawable(R.drawable.selectedgif));
             }
@@ -499,6 +511,7 @@ public class Gifgridviewpopup extends PopupWindow {
                 }
                 subcatadapter = new Subcatadapter( subcategoriesmodelArrayList, mContext);
                 subcatrec.setAdapter(subcatadapter);
+                subcatrec.setVisibility(View.VISIBLE);
 
                 subcatrec.addOnItemTouchListener(new RecyclerItemClickListener(mContext, subcatrec, new RecyclerItemClickListener.OnItemClickListener() {
                     @Override
@@ -550,15 +563,15 @@ public class Gifgridviewpopup extends PopupWindow {
         progresbarfulli.setVisibility(View.VISIBLE);
         progresbarfull.animate();
         progresbarfull.setIndeterminate(true);
-      SettingSesson settingSesson =  new SettingSesson(mContext);
+        SettingSesson settingSesson =  new SettingSesson(mContext);
         RequestQueue queue = Volley.newRequestQueue(mContext);
         //String subcaturl ="https://d9.technikh.com/index.php/api/v1/gif/search/all?sub-category-id="+subcategoryid+"&languages="+ settingSesson.getSlelectedlang() +"&current_page="+pagenumber;
         //String subcaturl ="https://staticapis.pragament.com/language_learning/gif-data.json";
         String subcaturl ="https://expressjs-api-chat-keyboard.onrender.com/api/v1/items?sub-category-id="+subcategoryid+"&languages="+ settingSesson.getSlelectedlang() +"&current_page="+pagenumber;
-      if(pagenumber ==1)
-      {
-          subgifdataArrayList.clear();
-      }
+        if(pagenumber ==1)
+        {
+            subgifdataArrayList.clear();
+        }
 
 // Request a string response from the provided URL.
         JsonObjectRequest subcatjsonObjectRequest = new JsonObjectRequest(subcaturl, new Response.Listener<JSONObject>() {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://maven.google.com' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.8.1'
+        classpath 'com.android.tools.build:gradle:8.10.1'
         classpath 'com.google.gms:google-services:4.3.10'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Sep 25 20:46:17 IST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Fixed

1.  When the search input is empty:
2.  Displays **recent GIFs** from `HistoryViewModel`
3.  Shows **categories** and **subcategories**
4. Works even when **“Show search screen by default”** is enabled in settings

 Affected File

- `Gifgridviewpopup.java`: Logic added to `createCustomView()` to trigger `makeCategories()` + `getAllRecentGifs()` when search is empty
